### PR TITLE
Adaption of git_source

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -22,7 +22,7 @@ class puppetboard::params {
   $group = 'puppetboard'
   $groups = undef
   $basedir = '/srv/puppetboard'
-  $git_source = 'https://github.com/nedap/puppetboard'
+  $git_source = 'https://github.com/voxpupuli/puppet-puppetboard'
 
   $puppetdb_host = 'localhost'
   $puppetdb_port = 8080


### PR DESCRIPTION
The git_source "https://github.com/nedap/puppetboard" is not longer working, we should use as a new default parameter: "https://github.com/voxpupuli/puppet-puppetboard".
